### PR TITLE
Improve task info stack layout

### DIFF
--- a/TaskGuru/Core/Home/HomeListCell.swift
+++ b/TaskGuru/Core/Home/HomeListCell.swift
@@ -21,9 +21,7 @@ struct HomeListCell: View {
 	]
 
 	var body: some View {
-        let lowerLayout = dynamicTypeSize <= .xLarge ?
-		AnyLayout(HStackLayout(alignment: .center)) :
-		AnyLayout(VStackLayout(alignment: .leading))
+        let lowerLayout = decideOutmostLowerLayout()
 
         let nestedLowerFirstHalfLayout = dynamicTypeSize <= .accessibility1 ?
         AnyLayout(HStackLayout(alignment: .center)) :
@@ -144,6 +142,28 @@ extension HomeListCell {
 }
 
 extension HomeListCell {
+	private func decideOutmostLowerLayout() -> AnyLayout {
+		var layout: AnyLayout
+		let preferredHorizontalLayout = AnyLayout(HStackLayout(alignment: .center))
+		let preferredVerticalLayout = AnyLayout(VStackLayout(alignment: .leading))
+
+		// When font size is larger than 120%
+		if dynamicTypeSize > .xxLarge {
+			layout = preferredVerticalLayout
+		} else {
+			layout = preferredHorizontalLayout
+		}
+
+		// When font size is larger than 100%, user turned on "Relative date time" mode, and task is in progress
+		if dynamicTypeSize > .large && isRelativeDateTime && task.status == .inProgress {
+			layout = preferredVerticalLayout
+		} else {
+			layout = preferredHorizontalLayout
+		}
+
+		return layout
+	}
+
 	private var accessibilityString: String {
 		var string = ""
 		string.append("Task name: \(task.name),")

--- a/TaskGuru/Core/Home/HomeListCell.swift
+++ b/TaskGuru/Core/Home/HomeListCell.swift
@@ -122,7 +122,7 @@ extension HomeListCell {
 
 	private var taskDueDate: some View {
 		Label {
-			Text(task.shortDueDate)
+			Text(isRelativeDateTime ? task.relativeDueDate : task.shortDueDate)
 		} icon: {
 			SFSymbols.alarm.font(.caption)
 		}

--- a/TaskGuru/Core/Home/HomeListCell.swift
+++ b/TaskGuru/Core/Home/HomeListCell.swift
@@ -12,7 +12,7 @@ struct HomeListCell: View {
 	@ObservedObject var task: TaskItem
 	@Preference(\.isRelativeDateTime) private var isRelativeDateTime
 	@Preference(\.isTodayDuesHighlighted) private var isCellHighlighted
-	@Environment(\.dynamicTypeSize) var dynamicTypeSize
+	@Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
 	private let columns = [
 		GridItem(.flexible(), alignment: .leading),
@@ -21,9 +21,13 @@ struct HomeListCell: View {
 	]
 
 	var body: some View {
-		let lowerLayout = dynamicTypeSize <= .xxLarge ?
+        let lowerLayout = dynamicTypeSize <= .xLarge ?
 		AnyLayout(HStackLayout(alignment: .center)) :
 		AnyLayout(VStackLayout(alignment: .leading))
+
+        let nestedLowerFirstHalfLayout = dynamicTypeSize <= .accessibility1 ?
+        AnyLayout(HStackLayout(alignment: .center)) :
+        AnyLayout(VStackLayout(alignment: .leading))
 
 		VStack(alignment: .leading) {
 			HStack(alignment: .top) {
@@ -33,8 +37,10 @@ struct HomeListCell: View {
 			.bold(task.isNotDone ? true : false)
 
 			lowerLayout {
-				taskStatus.padding(.trailing, 12)
-				taskDueDate.padding(.trailing, 12)
+                nestedLowerFirstHalfLayout {
+                    taskStatus.padding(.trailing, 12)
+                    taskDueDate.padding(.trailing, 12)
+                }
 				taskType
 			}
 		}


### PR DESCRIPTION
Finer, more granular dynamic stack layout for a task cell's lower text is needed, because the current look from above 100% to 160% font size settings is not preferred.

Therefore, I made the stack view layout more adaptive to specific cases, so it looks nicer.